### PR TITLE
Add ro.liquid.fingerprint property

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -318,11 +318,16 @@ else
     endif
 endif
 
+TARGET_PRODUCT_SHORT := $(subst liquid_,,$(LIQUID_BUILDTYPE))
+
+ROM_FINGERPRINT := LiquidRemix/$(PLATFORM_VERSION)/$(TARGET_PRODUCT_SHORT)/$(shell date +%Y%m%d)
+
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.liquid.version=$(LIQUID_VERSION) \
     ro.liquid.releasetype=$(LIQUID_BUILDTYPE) \
     ro.liquid.build.version=$(PRODUCT_VERSION_MAJOR).$(PRODUCT_VERSION_MINOR) \
-    ro.modversion=$(LIQUID_VERSION)
+    ro.modversion=$(LIQUID_VERSION) \
+    ro.liquid.fingerprint=$(ROM_FINGERPRINT)
 
 LIQUID_DISPLAY_VERSION := $(LIQUID_VERSION)
 


### PR DESCRIPTION
This commit fixes issue that often occurs after a dirty flash where settings screen has mixed up names and strings. Issue is manually fixed after dirty flash by deleting contents of /data/system/package_cache. that is no longer needed after picking this into my forked repo



- Remove cache script inheritance

Change-Id: If3fd8866bd88ba135f248c2a95bee31a35fb096e
Signed-off-by: Josh Fox (XlxFoXxlX) <joshfox87@gmail.com>