### PR TITLE
Add QS edit item decoration background color

### DIFF
--- a/themes/Black/SystemUI/res/values/colors.xml
+++ b/themes/Black/SystemUI/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- QS edit page background color -->
+    <color name="qs_edit_item_decoration_bg">@*android:color/black</color>
+
+</resources>

--- a/themes/Dark/SystemUI/res/values/colors.xml
+++ b/themes/Dark/SystemUI/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- QS edit page background color -->
+    <color name="qs_edit_item_decoration_bg">@*android:color/secondary_device_default_settings</color>
+
+</resources>


### PR DESCRIPTION
Fixes theming issue of qs tile edit page on dark/black themes
Signed-off-by: sayan7848 <sayan7848@gmail.com>